### PR TITLE
fix: removing public version function and struct

### DIFF
--- a/src/contracts/proxy/AgoraTransparentUpgradeableProxy.sol
+++ b/src/contracts/proxy/AgoraTransparentUpgradeableProxy.sol
@@ -63,14 +63,4 @@ contract AgoraTransparentUpgradeableProxy is Proxy {
     function _implementation() internal view virtual override returns (address) {
         return ERC1967Utils.getImplementation();
     }
-
-    struct Version {
-        uint256 major;
-        uint256 minor;
-        uint256 patch;
-    }
-
-    function version() public pure returns (Version memory _version) {
-        return Version({ major: 1, minor: 0, patch: 0 });
-    }
 }

--- a/src/contracts/proxy/AgoraTransparentUpgradeableProxy.sol
+++ b/src/contracts/proxy/AgoraTransparentUpgradeableProxy.sol
@@ -23,7 +23,7 @@ struct ConstructorParams {
 }
 
 contract AgoraTransparentUpgradeableProxy is Proxy {
-    address private immutable _admin;
+    address private _admin;
 
     /**
      * @dev The proxy caller is the current admin, and can't fallback to the proxy target.


### PR DESCRIPTION
Having a public version on the proxy invalidates the underlying `version()` function in the implementation. This PR removes `version()` on the proxy and `Version` struct